### PR TITLE
fix: Unnecessary wildcard key issues

### DIFF
--- a/test/assert/assert.rego
+++ b/test/assert/assert.rego
@@ -82,7 +82,7 @@ not_has_key(key, obj) := false if {
 # METADATA
 # description: Assert value is in obj
 has_value(value, obj) if {
-	some _, values in obj
+	some values in obj
 	value == values
 } else := false if {
 	print("expected", type_name(value), _quote_str(value), "in", type_name(obj), "got:", obj)
@@ -91,7 +91,7 @@ has_value(value, obj) if {
 # METADATA
 # description: Assert value is not in obj
 not_has_value(value, obj) := false if {
-	some _, values in obj
+	some values in obj
 	value == values
 } else if {
 	print("expected", type_name(value), _quote_str(value), "not in", type_name(obj), "got:", obj)


### PR DESCRIPTION
Hey, really love your project, I am learning opa / rego and it has been  really helpful in writing tests.

the latest version of regal now checks for unnecessary wildcard keys

```
jmainguy@fedora:~/Github/rego-test-assertions$ regal lint .
Rule:         	in-wildcard-key                                             	
Description:  	Unnecessary wildcard key                                    	
Category:     	idiomatic                                                   	
Location:     	test/assert/assert.rego:85:7                                	
Text:         	some _, values in obj                                       	
Documentation:	https://docs.styra.com/regal/rules/idiomatic/in-wildcard-key	
              	
Rule:         	in-wildcard-key                                             	
Description:  	Unnecessary wildcard key                                    	
Category:     	idiomatic                                                   	
Location:     	test/assert/assert.rego:94:7                                	
Text:         	some _, values in obj                                       	
Documentation:	https://docs.styra.com/regal/rules/idiomatic/in-wildcard-key
```

This PR is aimed to fix those findings. Tests appear to be passing still after change

```
jmainguy@fedora:~/Github/rego-test-assertions$ opa test .
PASS: 37/37
```
